### PR TITLE
the field kategorie should be integer to avoid sql errors

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,7 +7,7 @@ CREATE TABLE tx_waconcookiemanagement_domain_model_cookie (
 	pid int(11) DEFAULT '0' NOT NULL,
 
 	bezeichnung varchar(255) DEFAULT '' NOT NULL,
-	kategorie varchar(255) DEFAULT '' NOT NULL,
+	kategorie int(11) DEFAULT '0' NOT NULL,
 	anbieter varchar(255) DEFAULT '' NOT NULL,
 	zweck text,
 	cookiename varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
by running typo3 on postgres the type varchar of the field kategorie caused errors